### PR TITLE
Specify the path of your component binary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Using
 Usage is almost identical to ``component install`` just with a different
 invocation. In order to use run the following command::
 
-    component proxy-install
+    component-proxy-install PATH_TO_YOUR_COMPONENT_BINARY
 
 Any options you pass will be passed to ``component install``
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Using
 Usage is almost identical to ``component install`` just with a different
 invocation. In order to use run the following command::
 
-    component-proxy-install PATH_TO_YOUR_COMPONENT_BINARY
+    component-proxy-install
 
 Any options you pass will be passed to ``component install``
 

--- a/bin/component-proxy-install
+++ b/bin/component-proxy-install
@@ -2,6 +2,9 @@
 var app = require('../');
 var spawn = require('child_process').spawn;
 
+// Get the path to the component binary that is gonna be used
+var componentBinary = process.argv[2];
+
 // Run the server
 console.log('Starting component proxy');
 app.start();
@@ -9,10 +12,10 @@ app.start();
 var port = app.getPort();
 
 var installArgs = [ 'install', '-r', 'https://raw.githubusercontent.com,http://127.0.0.1:' + port ];
-installArgs = installArgs.concat(process.argv.slice(2));
+installArgs = installArgs.concat(process.argv.slice(3));
 
 // Run the install process
-var installProc = spawn('./node_modules/.bin/component', installArgs);
+var installProc = spawn(componentBinary, installArgs);
 
 installProc.stdout.on('data', function(data) {
   process.stdout.write('' + data);

--- a/bin/component-proxy-install
+++ b/bin/component-proxy-install
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 var app = require('../');
 var spawn = require('child_process').spawn;
+var path = require('path');
 
-// Get the path of the loaded file for the `component` module
-var componentPath = require.resolve('component');
-// Now, we must have a string like /path/to/the/component/node_modules/probably/some/directories/index.js
-// We want to get the deeper `node_modules` directory and access to the `.bin` directory it contains
-var componentPathSeeker = new RegExp('(.*/node_modules/).*?');
-var componentBinaryPath = componentPathSeeker.exec(componentPath)[1] + '.bin/component';
+// Get the path of the `component` module
+var componentPath = path.resolve(require.resolve('component'), '../');
+
+// We only support Component v0.18.0. Let's make sure we are about to use the right one
+var componentPackageInfo = require(path.resolve(componentPath, 'package.json'));
+if (componentPackageInfo.version !== '0.18.0') {
+	console.error('We only support the version 0.18.0 of Component. Yours is currently ' + componentPackageInfo.version);
+	process.exit(1);
+}
+
+// Component binary
+var componentBinaryPath = path.resolve(componentPath, 'bin/component');
 
 // Run the server
 console.log('Starting component proxy');

--- a/bin/component-proxy-install
+++ b/bin/component-proxy-install
@@ -2,8 +2,12 @@
 var app = require('../');
 var spawn = require('child_process').spawn;
 
-// Get the path to the component binary that is gonna be used
-var componentBinary = process.argv[2];
+// Get the path of the loaded file for the `component` module
+var componentPath = require.resolve('component');
+// Now, we must have a string like /path/to/the/component/node_modules/probably/some/directories/index.js
+// We want to get the deeper `node_modules` directory and access to the `.bin` directory it contains
+var componentPathSeeker = new RegExp('(.*/node_modules/).*?');
+var componentBinaryPath = componentPathSeeker.exec(componentPath)[1] + '.bin/component';
 
 // Run the server
 console.log('Starting component proxy');
@@ -12,10 +16,10 @@ app.start();
 var port = app.getPort();
 
 var installArgs = [ 'install', '-r', 'https://raw.githubusercontent.com,http://127.0.0.1:' + port ];
-installArgs = installArgs.concat(process.argv.slice(3));
+installArgs = installArgs.concat(process.argv.slice(2));
 
 // Run the install process
-var installProc = spawn(componentBinary, installArgs);
+var installProc = spawn(componentBinaryPath, installArgs);
 
 installProc.stdout.on('data', function(data) {
   process.stdout.write('' + data);


### PR DESCRIPTION
# What is in ?

This Pull Request comes with a small modification letting the developer specify the path of the component binary he wants to be used.
The current state of this repository forces the developer to have its working directory set to somewhere where `node_modules/.bin/component` is reachable, which is, in my opinion, not the best solution as it comes with constraints.
